### PR TITLE
Add async upload response model

### DIFF
--- a/backend/api/upload.py
+++ b/backend/api/upload.py
@@ -2,24 +2,16 @@
 Upload API endpoints for handling file uploads and analysis.
 """
 
-from fastapi import APIRouter, UploadFile, HTTPException, File, Form, Depends
-from backend.services.extractor import extract_text_and_pages
-from similarity.tfidf import analyze_document_pages
-from backend.services.logger import log_upload
-from backend.models.schemas import UploadResponse
-from utils.duplicate_analysis import (
-    compute_document_hash,
-    compute_document_tfidf_vector
-)
-from utils.page_tracker import update_page_hash_map
-from similarity.engine import SimilarityEngine
-from utils.database import get_db, DocumentMetadata, Page, PageDuplicate, upsert_document_metadata, create_page, create_page_duplicate
+from fastapi import APIRouter, UploadFile, HTTPException, File, Depends
+from typing import List
+import tempfile
+from backend.models.schemas import AsyncUploadResponse
+from backend.tasks.pipeline_tasks import process_document_task
+from utils.config import settings
+from utils.database import get_db
 from sqlalchemy.orm import Session
 import uuid
 import os
-from datetime import datetime
-from typing import List
-import tempfile
 import logging
 
 # Set up logging
@@ -29,16 +21,16 @@ logger = logging.getLogger(__name__)
 router = APIRouter(tags=["Upload"])
 
 
-@router.post("/", response_model=UploadResponse)
-async def upload_document(file: UploadFile = File(...), db: Session = Depends(get_db)):
+@router.post("/", response_model=AsyncUploadResponse)
+async def upload_document(file: UploadFile = File(...), db: Session = Depends(get_db)) -> AsyncUploadResponse:
     """
-    Upload and analyze a single document.
+    Upload a document and queue it for asynchronous processing.
     
     Args:
         file: PDF file to upload
         
     Returns:
-        UploadResponse with analysis results
+        AsyncUploadResponse containing task information
         
     Raises:
         HTTPException: If upload or analysis fails
@@ -48,199 +40,23 @@ async def upload_document(file: UploadFile = File(...), db: Session = Depends(ge
     if not file.filename.endswith('.pdf'):
         logger.warning(f"Rejected non-PDF file: {file.filename}")
         raise HTTPException(status_code=400, detail="Only PDF files are supported")
-    
-    temp_path = None
+
     try:
-        # Generate doc_id
         doc_id = str(uuid.uuid4())
-        temp_path = f"storage/tmp/{doc_id}_{file.filename}"
-        
-        # Save uploaded file
+        os.makedirs(settings.TEMP_PATH, exist_ok=True)
+        temp_path = os.path.join(settings.TEMP_PATH, f"{doc_id}_{file.filename}")
+
         logger.debug(f"Saving uploaded file to {temp_path}")
         with open(temp_path, "wb") as f:
-            content = await file.read()
-            f.write(content)
+            f.write(await file.read())
 
-        # Create directories for page images
-        os.makedirs("storage/page_images", exist_ok=True)
+        task = process_document_task.delay(temp_path, file.filename, doc_id)
+        logger.info(f"Queued processing task {task.id} for doc {doc_id}")
+        return AsyncUploadResponse(doc_id=doc_id, task_id=task.id)
 
-        # Extract text and analyze
-        full_text, pages_data = extract_text_and_pages(temp_path, doc_id=doc_id)
-        
-        # Update page hash map with the extracted pages
-        logger.debug("Updating page hash map")
-        page_texts = [p['text'] for p in pages_data]
-        medical_confidences = [p.get('medical_confidence', 0.0) for p in pages_data]
-        duplicate_confidences = [p.get('duplicate_confidence', 0.0) for p in pages_data]
-        
-        # Create page images and store their paths
-        image_paths = []
-        for i, page_data in enumerate(pages_data, 1):
-            # Generate page images using PyMuPDF or pdf2image
-            # This would be implemented in a page rendering service
-            image_path = f"storage/page_images/{doc_id}_page{i}.png"
-            image_paths.append(image_path)
-        
-        # Update page hash map
-        update_page_hash_map(
-            doc_id=doc_id,
-            filename=file.filename,
-            page_texts=page_texts,
-            medical_confidences=medical_confidences,
-            duplicate_confidences=duplicate_confidences,
-            image_paths=image_paths
-        )
-
-        # Analyze pages for duplicates
-        try:
-            logger.debug("Starting page analysis")
-            similar_pairs = analyze_document_pages(pages_data)
-            logger.debug(f"Found {len(similar_pairs)} similar page pairs")
-            
-            # Convert to page metadata format
-            page_metadata = []
-            for i, page in enumerate(pages_data):
-                page_metadata.append({
-                    "page_num": i + 1,
-                    "page_hash": page["page_hash"],
-                    "text_snippet": page["text_snippet"]
-                })
-            
-            # Find duplicates
-            duplicates = []
-            for pair in similar_pairs:
-                page1_idx = pair["page1_idx"]
-                page2_idx = pair["page2_idx"]
-                similarity = pair["similarity"]
-                
-                logger.debug(f"Duplicate found: pages {page1_idx} and {page2_idx} with similarity {similarity}")
-                duplicates.append({
-                    "page1_idx": page1_idx,
-                    "page2_idx": page2_idx,
-                    "similarity": similarity
-                })
-            
-            # Determine overall status
-            status = "duplicate" if duplicates else "unique"
-            logger.debug(f"Document status: {status}")
-            
-        except Exception as e:
-            logger.error(f"Page analysis failed: {str(e)}", exc_info=True)
-            raise HTTPException(status_code=500, detail=f"Failed to analyze document: {str(e)}")
-
-        # Store document metadata in the database
-        try:
-            logger.debug("Storing document metadata in DB")
-            
-            # Compute document hash
-            document_content_hash = compute_document_hash(temp_path)
-            if not document_content_hash:
-                logger.warning(f"Could not compute content hash for {file.filename} at {temp_path}. Proceeding without it.")
-                # Decide if this is a critical failure. For now, allow proceeding.
-            
-            # Upsert DocumentMetadata
-            db_document = upsert_document_metadata(
-                db=db,
-                doc_id=doc_id,
-                filename=file.filename,
-                status=status,
-                upload_timestamp=datetime.utcnow(),
-                page_count=len(page_metadata),
-                content_hash=document_content_hash,
-                file_path=temp_path
-            )
-            
-            # Store Page information
-            db_pages = {} # To map page_idx to Page object for duplicate creation
-            for i, p_meta in enumerate(page_metadata):
-                db_page = create_page(
-                    db=db,
-                    document_id=doc_id,
-                    page_number=p_meta["page_num"], # page_metadata is 1-indexed from earlier
-                    page_hash=p_meta["page_hash"],
-                    text_snippet=p_meta["text_snippet"],
-                    # image_paths are already handled by update_page_hash_map for now
-                    # We might need to consolidate this if update_page_hash_map is also refactored
-                )
-                db_pages[i] = db_page # page_metadata used 0-indexed loop for pages_data
-
-            # Store DuplicatePair information
-            # The 'duplicates' list contains page1_idx and page2_idx which are 0-indexed
-            for dup_pair in duplicates:
-                page1_db_id = None
-                page2_db_id = None
-
-                # Find the corresponding Page objects from db_pages
-                # The indices in dup_pair (page1_idx, page2_idx) correspond to the original pages_data list
-                # And page_metadata was created by iterating pages_data with enumerate
-                
-                # Check if page1_idx and page2_idx are valid keys in db_pages
-                if dup_pair["page1_idx"] in db_pages:
-                    page1_db_id = db_pages[dup_pair["page1_idx"]].id
-                else:
-                    logger.error(f"Could not find page with original index {dup_pair['page1_idx']} in db_pages for doc {doc_id}")
-                    continue
-
-                if dup_pair["page2_idx"] in db_pages:
-                    page2_db_id = db_pages[dup_pair["page2_idx"]].id
-                else:
-                    logger.error(f"Could not find page with original index {dup_pair['page2_idx']} in db_pages for doc {doc_id}")
-                    continue
-                
-                if page1_db_id and page2_db_id:
-                    create_page_duplicate(
-                        db=db,
-                        source_page_id=page1_db_id,
-                        duplicate_page_id=page2_db_id,
-                        similarity=dup_pair["similarity"]
-                    )
-                else:
-                    logger.warning(f"Could not create PageDuplicate for pair {dup_pair} due to missing page IDs.")
-            
-            db.commit() # Commit all changes for this document
-            logger.info(f"Successfully stored metadata for document {doc_id} in DB")
-                
-        except Exception as e:
-            db.rollback() # Rollback in case of error
-            logger.error(f"Failed to store metadata in DB: {str(e)}", exc_info=True)
-            # Not raising HTTPException here to allow logging and response, but original code had a warning
-            # Re-evaluating if this should be a critical failure or just a warning.
-            # For now, let's maintain the original behavior of logging a warning and continuing.
-            logger.warning(f"Failed to store document metadata in DB: {str(e)}")
-
-        # Log the upload
-        try:
-            logger.debug("Logging upload")
-            log_upload(doc_id=doc_id, filename=file.filename, status=status)
-        except Exception as e:
-            logger.error(f"Logging failed: {str(e)}", exc_info=True)
-            logger.warning(f"Failed to log upload: {str(e)}")
-
-        # Return structured response
-        response = UploadResponse(
-            doc_id=doc_id,
-            status=status,
-            match=None,
-            pages=page_metadata,
-            duplicates=duplicates
-        )
-        logger.debug(f"Returning response: {response}")
-        return response
-
-    except HTTPException:
-        raise
     except Exception as e:
-        logger.error(f"Unexpected error: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Upload failed: {str(e)}")
-    finally:
-        # Clean up temporary file
-        try:
-            if temp_path and os.path.exists(temp_path):
-                os.remove(temp_path)
-                logger.debug(f"Cleaned up temp file: {temp_path}")
-        except Exception as e:
-            logger.error(f"Cleanup failed: {str(e)}", exc_info=True)
-            logger.warning(f"Failed to clean up temporary file: {str(e)}")
+        logger.error(f"Unexpected error: {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Upload failed: {e}")
 
 
 @router.post("/batch")

--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -63,6 +63,14 @@ class UploadResponse(BaseModel):
     duplicates: List[DuplicatePair] = []
 
 
+class AsyncUploadResponse(BaseModel):
+    """Response returned when an upload is queued for async processing."""
+
+    doc_id: str
+    task_id: str
+    status: Optional[str] = "queued"
+
+
 class ReviewRequest(BaseModel):
     """
     Payload sent when a reviewer makes a decision.

--- a/frontend/services/documentService.ts
+++ b/frontend/services/documentService.ts
@@ -3,6 +3,7 @@ import {
   DocumentAnalysis,
   PageMetadata,
   UploadResponse,
+  AsyncUploadResponse,
   ReviewRequest,
   PageMetadataResponse,
   BatchFolderResponse,
@@ -17,7 +18,7 @@ export const documentService = {
   /**
    * Upload a single document for analysis
    */
-  async uploadDocument(file: File): Promise<UploadResponse> {
+  async uploadDocument(file: File): Promise<AsyncUploadResponse> {
     const formData = new FormData();
     formData.append('file', file);
     
@@ -145,7 +146,7 @@ export const documentService = {
 /**
  * Helper function for single document upload
  */
-export async function uploadSingle(file: File) {
+export async function uploadSingle(file: File): Promise<AsyncUploadResponse> {
   const form = new FormData();
   form.append("file", file);
   

--- a/frontend/types/document.ts
+++ b/frontend/types/document.ts
@@ -60,13 +60,19 @@ export interface PageInfo {
     similarity: number;
   }
   
-  export interface UploadResponse {
+export interface UploadResponse {
     doc_id: string;
     status: string;
     match?: MatchDetails | null;
     pages: PageMetadata[];
     duplicates?: DuplicateMatch[];
-  }
+}
+
+export interface AsyncUploadResponse {
+  doc_id: string;
+  task_id: string;
+  status?: string;
+}
   
   export interface ReviewRequest {
     doc_id: string;


### PR DESCRIPTION
## Summary
- support async uploads by returning AsyncUploadResponse
- expose AsyncUploadResponse schema and types
- update document upload service to use the new model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684053988ebc832b8d6c23eb98e1a0ca