### PR TITLE
Add endpoint for TF-IDF intra-document analysis

### DIFF
--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -52,6 +52,12 @@ class DuplicatePair(BaseModel):
     similarity: float
 
 
+class IntraDocTFIDFResponse(BaseModel):
+    """Response model for intra-document TF-IDF analysis."""
+    doc_id: str
+    highSimilarityPairs: List[DuplicatePair]
+
+
 class UploadResponse(BaseModel):
     """
     Response returned after document upload and analysis.

--- a/similarity/tfidf.py
+++ b/similarity/tfidf.py
@@ -156,11 +156,16 @@ def _load_vectorizer() -> Optional[TfidfVectorizer]:
         except Exception as e:
             logger.error(f"Error loading or validating vectorizer from {VECTORIZER_FILE}: {e}. Returning None.", exc_info=True)
             VECTORIZER = None # Clear cache on error
-            return None
+        return None
     else:
         logger.warning(f"Vectorizer file {VECTORIZER_FILE} not found. No TF-IDF vectorizer available. Run the vectorizer management task.")
         VECTORIZER = None # Ensure cache is clear
         return None
+
+
+def load_fitted_tfidf_vectorizer() -> Optional[TfidfVectorizer]:
+    """Public wrapper for loading the fitted TF-IDF vectorizer."""
+    return _load_vectorizer()
 
 
 def _save_vectorizer(vectorizer: TfidfVectorizer) -> None:

--- a/utils/config.py
+++ b/utils/config.py
@@ -4,7 +4,7 @@ Uses Pydantic for settings management and validation.
 """
 
 import os
-from pydantic_settings import BaseSettings
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic import Field
 from typing import List, Dict, Optional, Any
 from dotenv import load_dotenv
@@ -68,6 +68,9 @@ class Settings(BaseSettings):
     REDIS_PORT: int = Field(default=6379, env="REDIS_PORT")
     CELERY_BROKER_URL: Optional[str] = Field(default=None, env="CELERY_BROKER_URL")
     CELERY_RESULT_BACKEND: Optional[str] = Field(default=None, env="CELERY_RESULT_BACKEND")
+
+    # Database settings
+    DATABASE_URL: str = Field(default="sqlite:///./test.db", env="DATABASE_URL")
     
     # Processing limits
     MAX_BATCH_SIZE: int = Field(default=100, env="MAX_BATCH_SIZE")
@@ -79,10 +82,12 @@ class Settings(BaseSettings):
     # Thumbnail generation
     THUMBNAIL_SIZE: tuple = Field(default=(200, 200))
     
-    class Config:
-        env_file = ".env"
-        env_file_encoding = "utf-8"
-        case_sensitive = True
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=True,
+        extra="ignore",
+    )
 
 
 # Create global settings instance


### PR DESCRIPTION
## Summary
- provide `IntraDocTFIDFResponse` schema
- import TF‑IDF analyzer and DB helpers in documents API
- add `/documents/{doc_id}/analyze-internal-pages` endpoint

## Testing
- `python -m py_compile backend/api/documents.py backend/models/schemas.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406d17ef24832bb8f036801d47f21f