### PR TITLE
Implement Option 3 intra-doc analysis

### DIFF
--- a/backend/api/documents.py
+++ b/backend/api/documents.py
@@ -483,7 +483,7 @@ async def analyze_internal_pages(
     if not pages:
         raise HTTPException(status_code=404, detail=f"Document {doc_id} not found or has no pages")
 
-    page_texts = [p.text_snippet or "" for p in pages]
+    page_texts = [p.full_page_text or p.text_snippet or "" for p in pages]
     tfidf_pairs = tfidf_analyze_document_pages(page_texts, threshold=threshold)
 
     results = [

--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -75,6 +75,13 @@ class UploadTaskResponse(BaseModel):
     task_id: str
 
 
+class AsyncUploadResponse(BaseModel):
+    """Immediate response for asynchronous document upload."""
+    message: str
+    doc_id: str
+    task_id: str
+
+
 class ReviewRequest(BaseModel):
     """
     Payload sent when a reviewer makes a decision.

--- a/frontend/services/documentService.ts
+++ b/frontend/services/documentService.ts
@@ -117,6 +117,16 @@ export const documentService = {
     
     return response.data;
   },
+
+  /**
+   * Analyze stored document pages by doc_id
+   */
+  async analyzeStoredDocument(docId: string, threshold: number): Promise<any> {
+    const response = await api.get(`/documents/${docId}/analyze-internal-pages`, {
+      params: { threshold }
+    });
+    return response.data;
+  },
   
   /**
    * Rebuild a document using selected pages

--- a/utils/database.py
+++ b/utils/database.py
@@ -107,6 +107,7 @@ class Page(Base): # type: ignore
     page_number = Column(Integer, nullable=False)
     page_hash = Column(String, nullable=False, index=True)
     text_snippet = Column(Text, nullable=True)
+    full_page_text = Column(Text, nullable=True)
     page_image_path = Column(String, nullable=True)
     medical_confidence = Column(Float, nullable=True)
     duplicate_confidence = Column(Float, nullable=True)
@@ -325,8 +326,9 @@ def get_recent_document_metadata(db: Session, limit: int = 10) -> List[DocumentM
 
 # --- CRUD Helper Functions for Page ---
 
-def create_page(db: Session, document_id: str, page_number: int, page_hash: str, 
-                text_snippet: Optional[str] = None, 
+def create_page(db: Session, document_id: str, page_number: int, page_hash: str,
+                text_snippet: Optional[str] = None,
+                full_page_text: Optional[str] = None,
                 page_image_path: Optional[str] = None,
                 medical_confidence: Optional[float] = None,
                 duplicate_confidence: Optional[float] = None,
@@ -338,6 +340,7 @@ def create_page(db: Session, document_id: str, page_number: int, page_hash: str,
         page_number=page_number,
         page_hash=page_hash,
         text_snippet=text_snippet,
+        full_page_text=full_page_text,
         page_image_path=page_image_path,
         medical_confidence=medical_confidence,
         duplicate_confidence=duplicate_confidence,

--- a/utils/page_tracker.py
+++ b/utils/page_tracker.py
@@ -103,6 +103,7 @@ def process_document_pages( # Renamed from update_page_hash_map for clarity and 
             page_number=page_num,
             page_hash=page_hash_val,
             text_snippet=text[:300].replace("\n", " ").strip(),
+            full_page_text=text,
             medical_confidence=medical_confidences[page_num-1],
             duplicate_confidence=duplicate_confidences[page_num-1],
             page_image_path=image_paths[page_num-1], # type: ignore


### PR DESCRIPTION
## Summary
- store full page text in the `Page` table and save during ingestion
- allow analysis of stored documents to use full page text
- expose new API method on the frontend to call `/documents/{doc_id}/analyze-internal-pages`
- update IntraDocumentComparison UI to accept a document ID instead of a file upload

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840780d4634832b896efbccf4526739