### PR TITLE
Fix TS type issues and CLI similarity import

### DIFF
--- a/frontend/components/analysis/DocumentComparison.tsx
+++ b/frontend/components/analysis/DocumentComparison.tsx
@@ -11,24 +11,22 @@ interface Props {
   onComplete?: (data: ReviewData) => void;
 }
 
+interface ComparisonPage {
+  pageNumber: number;
+  imageUrl: string;
+  similarity: number;
+}
+
 interface ComparisonResult {
   doc1: {
     text: string;
     filename: string;
-    pages: {
-      pageNumber: number;
-      imageUrl: string;
-      similarity: number;
-    }[];
+    pages: ComparisonPage[];
   };
   doc2: {
     text: string;
     filename: string;
-    pages: {
-      pageNumber: number;
-      imageUrl: string;
-      similarity: number;
-    }[];
+    pages: ComparisonPage[];
   };
   similarity: number;
 }
@@ -75,14 +73,14 @@ export default function DocumentComparison({ onComplete }: Props) {
       
       // Fix image URLs - convert relative URLs to absolute URLs
       if (result.doc1 && result.doc1.pages) {
-        result.doc1.pages = result.doc1.pages.map(page => ({
+        result.doc1.pages = result.doc1.pages.map((page: ComparisonPage) => ({
           ...page,
           imageUrl: getAbsoluteApiUrl(page.imageUrl)
         }));
       }
-      
+
       if (result.doc2 && result.doc2.pages) {
-        result.doc2.pages = result.doc2.pages.map(page => ({
+        result.doc2.pages = result.doc2.pages.map((page: ComparisonPage) => ({
           ...page,
           imageUrl: getAbsoluteApiUrl(page.imageUrl)
         }));

--- a/frontend/components/analysis/IntraDocumentComparison.tsx
+++ b/frontend/components/analysis/IntraDocumentComparison.tsx
@@ -63,7 +63,7 @@ export default function IntraDocumentComparison({ onComplete }: Props) {
       
       // Fix image URLs - convert relative URLs to absolute URLs
       if (result.pages) {
-        result.pages = result.pages.map(page => ({
+        result.pages = result.pages.map((page: PageData) => ({
           ...page,
           imageUrl: getAbsoluteApiUrl(page.imageUrl)
         }));
@@ -81,8 +81,8 @@ export default function IntraDocumentComparison({ onComplete }: Props) {
         
         for (const pair of result.highSimilarityPairs) {
           // Get the image URLs from the results
-          const page1 = result.pages.find(p => p.pageNumber === pair.page1);
-          const page2 = result.pages.find(p => p.pageNumber === pair.page2);
+          const page1 = result.pages.find((p: PageData) => p.pageNumber === pair.page1);
+          const page2 = result.pages.find((p: PageData) => p.pageNumber === pair.page2);
           
           if (!page1 || !page2) {
             console.error(`Couldn't find page data for page ${pair.page1} or ${pair.page2}`);
@@ -285,7 +285,7 @@ export default function IntraDocumentComparison({ onComplete }: Props) {
                     </div>
                     <div className="border border-gray-700 rounded-lg overflow-hidden">
                       <img
-                        src={results.pages.find(p => p.pageNumber === results.highSimilarityPairs[currentPair].page1)?.imageUrl}
+                        src={results.pages.find((p: PageData) => p.pageNumber === results.highSimilarityPairs[currentPair].page1)?.imageUrl}
                         alt={`Page ${results.highSimilarityPairs[currentPair].page1}`}
                         className="w-full h-auto"
                       />
@@ -304,7 +304,7 @@ export default function IntraDocumentComparison({ onComplete }: Props) {
                     </div>
                     <div className="border border-gray-700 rounded-lg overflow-hidden">
                       <img
-                        src={results.pages.find(p => p.pageNumber === results.highSimilarityPairs[currentPair].page2)?.imageUrl}
+                        src={results.pages.find((p: PageData) => p.pageNumber === results.highSimilarityPairs[currentPair].page2)?.imageUrl}
                         alt={`Page ${results.highSimilarityPairs[currentPair].page2}`}
                         className="w-full h-auto"
                       />
@@ -326,7 +326,7 @@ export default function IntraDocumentComparison({ onComplete }: Props) {
                     <th className="px-3 py-2 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
                       
                     </th>
-                    {results.pages.map((page) => (
+                    {results.pages.map((page: PageData) => (
                       <th key={page.pageNumber} className="px-3 py-2 text-left text-xs font-medium text-gray-400 uppercase tracking-wider">
                         Page {page.pageNumber}
                       </th>
@@ -334,16 +334,17 @@ export default function IntraDocumentComparison({ onComplete }: Props) {
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-gray-700">
-                  {results.pages.map((page, i) => (
+                  {results.pages.map((page: PageData, i) => (
                     <tr key={page.pageNumber} className={i % 2 === 0 ? 'bg-gray-900' : 'bg-gray-800'}>
                       <td className="px-3 py-2 whitespace-nowrap text-sm font-medium text-white">
                         Page {page.pageNumber}
                       </td>
-                      {results.pages.map((otherPage) => {
+                      {results.pages.map((otherPage: PageData) => {
                         // Find similarity for this pair in the matrix
                         const pairData = results.similarityMatrix.find(
-                          p => (p.page1 === page.pageNumber && p.page2 === otherPage.pageNumber) ||
-                               (p.page2 === page.pageNumber && p.page1 === otherPage.pageNumber)
+                          (p: SimilarityPair) =>
+                            (p.page1 === page.pageNumber && p.page2 === otherPage.pageNumber) ||
+                            (p.page2 === page.pageNumber && p.page1 === otherPage.pageNumber)
                         );
                         
                         const similarity = page.pageNumber === otherPage.pageNumber ? 

--- a/frontend/types/document.ts
+++ b/frontend/types/document.ts
@@ -7,7 +7,8 @@
 export interface PageInfo {
     index: number;
     hash: string;
-    text: string;
+    text_snippet: string;
+    text?: string;
     medical_confidence?: number;
     duplicate_confidence?: number;
   }


### PR DESCRIPTION
## Summary
- type `ComparisonPage` and use when mapping page URLs
- annotate `PageData` usages in `IntraDocumentComparison`
- update `PageInfo` interface with `text_snippet`
- fix `batch_folder` CLI to use TF‑IDF vectors and `SimilarityEngine`

## Testing
- `pytest -q`
- `npx tsc -p frontend --noEmit` *(fails: Cannot find type definition file for 'node' and 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68405db06bbc832bba2999ad8a9b3290