### PR TITLE
Add endpoint for document processing status

### DIFF
--- a/backend/models/schemas.py
+++ b/backend/models/schemas.py
@@ -103,6 +103,14 @@ class DocumentStatusUpdate(BaseModel):
     notes: Optional[str] = None
 
 
+class DocumentStatusResponse(BaseModel):
+    """Status information for an uploaded document."""
+    doc_id: str
+    status: Optional[str] = None
+    task_state: Optional[str] = None
+    message: Optional[str] = None
+
+
 class RebuildRequest(BaseModel):
     """
     Request to rebuild a document from selected pages.


### PR DESCRIPTION
## Summary
- extend schemas with `DocumentStatusResponse`
- provide `GET /documents/{doc_id}/status` to report processing state

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68409e26f364832b8cbd1e9be4f4f3c8